### PR TITLE
Add ability to trigger multiple motions with one call

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -19,7 +19,7 @@ module.exports = function (self) {
 				{
 					type: 'textinput',
 					label: 'Motion Name',
-					tooltip: 'Separate multiple motions with , (comma)',
+					tooltip: 'Separate multiple motions with comma (e.g., motion_1, motion_2)',
 					id: 'motion_name',
 					regex: '/^[A-Za-z0-9_-]*$/',
 				},

--- a/actions.js
+++ b/actions.js
@@ -12,11 +12,14 @@ module.exports = function (self) {
 						{ id: 'play_motions', label: 'play_motions' },
 						{ id: 'stop_motions', label: 'stop_motions' },
 						{ id: 'finish_motions', label: 'finish_motions' },
+						{ id: 'pause_motions', label: 'pause_motions' },
+						
 					],
 				},
 				{
 					type: 'textinput',
 					label: 'Motion Name',
+					tooltip: 'Separate multiple motions with , (comma)',
 					id: 'motion_name',
 					regex: '/^[A-Za-z0-9_-]*$/',
 				},

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -1,11 +1,12 @@
 # Characterworks Companion Module
 
-v 2.0.0<br>
+v 2.0.1<br>
 5/6/23<br>
 Eddie Wettach <ewettach@gmail.com>
 
 ## Change Log
 
+2.0.1 - Added ability to trigger multiple motions in one request<br>
 2.0.0 - Added support for Companion version 3 <br>
 1.0.2 - Added ability to trigger grid buttons<br>
 1.0.1 - Initial CW Support - trigger motions and set text functions

--- a/main.js
+++ b/main.js
@@ -73,7 +73,7 @@ class ModuleInstance extends InstanceBase {
 				// create JSON data to HTTP POST to CW
 				var requestJSON = {
 					action: action.options.action_dropdown,
-					motions: [action.options.motion_name],
+					motions: action.options.motion_name.split(',').map(item=>item.trim()),
 					channel: action.options.channel_dropdown,
 				}
 				break

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "agf-characterworks",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"main": "main.js",
 	"scripts": {
 		"format": "prettier -w ."
@@ -8,7 +8,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/bitfocus/companion-module-your-module-name.git"
+		"url": "git+https://github.com/bitfocus/companion-module-agf-characterworks.git"
 	},
 	"dependencies": {
 		"@companion-module/base": "~1.4.0"


### PR DESCRIPTION
Adds the ability to trigger multiple motions by listing them separated with commas. This allows one HTTP request to handle multiple changes, which allows for better performance, since CharacterWorks will sometimes fail to handle multiple simultaneous HTTP requests.